### PR TITLE
REG-30: add race page with race actions and notifications

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -48,7 +48,7 @@ android {
         applicationId "com.example.regatta_buddy"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 23
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
     <application
         android:label="regatta_buddy"
         android:name="${applicationName}"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:regatta_buddy/pages/home.dart';
+import 'package:regatta_buddy/pages/race/race_page.dart';
 import 'package:regatta_buddy/pages/regatta_details.dart';
 import 'package:regatta_buddy/pages/route_creator.dart';
 import 'package:regatta_buddy/pages/search.dart';
@@ -21,6 +22,7 @@ class RegattaBuddy extends StatelessWidget {
         RegattaDetailsPage.route: (context) => const RegattaDetailsPage(),
         UserRegattasPage.route: (context) => const UserRegattasPage(),
         SearchPage.route: (context) => const SearchPage(),
+        RacePage.route: (context) => const RacePage(),
       },
     );
   }

--- a/lib/modals/action_button.dart
+++ b/lib/modals/action_button.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:regatta_buddy/utils/constants.dart' as constants;
+
+class ActionButton extends StatelessWidget {
+
+  ActionButton({
+    super.key,
+    this.size = 20,
+    this.iconData = Icons.question_mark,
+    this.title = "",
+    required this.onTap,
+    this.additionalCallback,
+  });
+
+  final double size;
+  final IconData iconData;
+  final String title;
+  final Function onTap;
+  Function? additionalCallback;
+
+  void setAdditionalCallback(Function callback) {
+    additionalCallback = callback;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.fromSize(
+      size: Size(size, size),
+
+      child: Material(
+        color: Colors.blue,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(constants.elementsBorderRadius)),
+        child: InkWell(
+          splashColor: Colors.lightBlueAccent,
+          onTap: () => {
+            onTap(),
+            if (additionalCallback != null) {
+              additionalCallback!()
+            }
+          },
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Icon(iconData, size: 80),
+              Text(title),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modals/actions_dialog.dart
+++ b/lib/modals/actions_dialog.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:regatta_buddy/modals/action_button.dart';
+import 'package:regatta_buddy/utils/constants.dart' as constants;
+
+Future<void> showActionsDialog(
+    BuildContext context, List<ActionButton> actions) async {
+  await Future.delayed(const Duration(seconds: 0));
+  if (context.mounted) {
+    showDialog(
+      barrierDismissible: true,
+      context: context,
+      builder: (BuildContext cxt) {
+        var autoClosingActions = actions.map((action) {
+          action.setAdditionalCallback(() => Navigator.of(cxt).pop(false));
+          return action;
+        }).toList();
+
+        return Align(
+          alignment: Alignment.center,
+          child: Padding(
+            padding: const EdgeInsets.all(constants.elementsBorderRadius),
+            child: Material(
+              color: Colors.white,
+              shape: RoundedRectangleBorder(
+                  borderRadius:
+                      BorderRadius.circular(constants.elementsBorderRadius)),
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: GridView.count(
+                  shrinkWrap: true,
+                  crossAxisCount: 2,
+                  mainAxisSpacing: 10,
+                  crossAxisSpacing: 10,
+                  children: autoClosingActions,
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/pages/race/race_page.dart
+++ b/lib/pages/race/race_page.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map_location_marker/flutter_map_location_marker.dart';
+import 'package:regatta_buddy/modals/action_button.dart';
+import 'package:regatta_buddy/modals/actions_dialog.dart' as actions_dialog;
+import 'package:regatta_buddy/pages/race/race_statistics.dart';
+import 'package:regatta_buddy/utils/constants.dart' as constants;
+import 'package:regatta_buddy/utils/externalAPIConstants.dart' as api_constants;
+import 'package:regatta_buddy/widgets/app_header.dart';
+import 'package:regatta_buddy/widgets/rb_notification.dart';
+import 'package:uuid/uuid.dart';
+
+class RacePage extends StatefulWidget {
+  const RacePage({super.key});
+
+  static const String route = '/race';
+
+  @override
+  State<RacePage> createState() => _RacePageState();
+}
+
+class _RacePageState extends State<RacePage> {
+  final int _notificationTimeInSeconds = 10;
+  List<RBNotification> activeNotifications = [];
+  List<ActionButton> raceActions = [];
+
+  void addNotification(String title) {
+    String uuid = const Uuid().v4();
+    activeNotifications.add(RBNotification(
+        uuid: uuid, title: title, onClose: () => removeNotification(uuid)));
+    Future.delayed(Duration(seconds: _notificationTimeInSeconds),
+        () => {removeNotification(uuid), setState(() {})});
+    setState(() {});
+  }
+
+  void removeNotification(String uuid) {
+    activeNotifications.removeWhere((element) => element.uuid == uuid);
+    setState(() {});
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    raceActions = [
+      ActionButton(
+          iconData: Icons.help_outline,
+          title: "Needs help",
+          onTap: () => addNotification("Help requested")),
+      ActionButton(
+          iconData: Icons.sports_kabaddi,
+          title: "Protest",
+          onTap: () => addNotification("Protest started")),
+      ActionButton(
+          iconData: Icons.question_answer,
+          title: "Problem",
+          onTap: () => addNotification("Judge was notified")),
+      ActionButton(
+          iconData: Icons.close_outlined, title: "Cancel", onTap: () => {})
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const AppHeader(),
+      body: Column(
+        children: [
+          Flexible(
+            child: Stack(children: [
+              FlutterMap(
+                mapController: MapController(),
+                options: MapOptions(
+                  center: constants.startingPosition,
+                  zoom: constants.startingZoom,
+                ),
+                nonRotatedChildren: const [
+                  SimpleAttributionWidget(
+                    source: Text(constants.attributionText),
+                  ),
+                ],
+                children: [
+                  TileLayer(
+                    urlTemplate: api_constants.tileLayerUrl,
+                    userAgentPackageName: api_constants.tileLayerUserAgent,
+                  ),
+                  CurrentLocationLayer(),
+                ],
+              ),
+              Positioned(
+                bottom: 32,
+                right: 32,
+                child: SizedBox(
+                    height: 60,
+                    width: 60,
+                    child: FloatingActionButton(
+                      elevation: 10,
+                      onPressed: () => actions_dialog.showActionsDialog(
+                          context, raceActions),
+                      child: const Icon(Icons.warning_amber_rounded, size: 35),
+                    )),
+              ),
+              const Positioned(
+                top: 0,
+                child: RaceStatistics(),
+              ),
+              Positioned(
+                  top: 85,
+                  child: Align(
+                      alignment: Alignment.center,
+                      child: Column(
+                        children: activeNotifications,
+                      )
+                  )
+              ),
+            ]),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/race/race_statistics.dart
+++ b/lib/pages/race/race_statistics.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:regatta_buddy/utils/constants.dart' as constants;
+
+class RaceStatistics extends StatelessWidget {
+  const RaceStatistics({
+    super.key,
+    this.height = 80,
+  });
+
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: height,
+      width: MediaQuery.of(context).size.width,
+      decoration: const BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.only(
+              bottomLeft: Radius.circular(constants.elementsBorderRadius),
+              bottomRight: Radius.circular(constants.elementsBorderRadius))),
+      child: const Padding(
+        padding: EdgeInsets.only(left: 20, right: 20),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  "Distance",
+                  style: TextStyle(
+                      color: Colors.black,
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold),
+                ),
+                Text(
+                  "0.00km",
+                  style: TextStyle(
+                      color: Colors.black,
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold),
+                ),
+              ],
+            ),
+            Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  "Time",
+                  style: TextStyle(
+                      color: Colors.black,
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold),
+                ),
+                Text(
+                  "0:00:00",
+                  style: TextStyle(
+                      color: Colors.black,
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold),
+                ),
+              ],
+            ),
+            Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  "Avg. Speed",
+                  style: TextStyle(
+                      color: Colors.black,
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold),
+                ),
+                Text(
+                  "0.00km/h",
+                  style: TextStyle(
+                      color: Colors.black,
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/user_regattas.dart
+++ b/lib/pages/user_regattas.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:regatta_buddy/pages/race/race_page.dart';
 import 'package:regatta_buddy/widgets/app_header.dart';
 
 class UserRegattasPage extends StatefulWidget {
@@ -13,9 +13,14 @@ class UserRegattasPage extends StatefulWidget {
 class _UserRegattasPageState extends State<UserRegattasPage> {
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    return Scaffold(
       appBar: AppHeader(),
-      body: Text('Page with regattas that user is participating in')
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () => Navigator.pushNamed(context, RacePage.route),
+          child: const Text('Page with regattas that user is participating in'),
+        ),
+      )
     );
   }
 }

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -1,0 +1,8 @@
+import 'package:latlong2/latlong.dart';
+
+const LatLng startingPosition = LatLng(54.372158, 18.638306);
+const double startingZoom = 12;
+
+const String attributionText = "OpenStreetMap contributors";
+
+const double elementsBorderRadius = 20;

--- a/lib/utils/externalAPIConstants.dart
+++ b/lib/utils/externalAPIConstants.dart
@@ -1,0 +1,4 @@
+// Contains values for external APIs communication
+
+const String tileLayerUrl = "https://tile.openstreetmap.org/{z}/{x}/{y}.png";
+const String tileLayerUserAgent = "com.regattaBuddy.app";

--- a/lib/widgets/rb_notification.dart
+++ b/lib/widgets/rb_notification.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:regatta_buddy/utils/constants.dart' as constants;
+
+class RBNotification extends StatelessWidget {
+  const RBNotification({
+    super.key,
+    required this.uuid,
+    required this.title,
+    required this.onClose,
+    this.height = 80,
+    this.additionalText = "",
+  });
+
+  final double height;
+  final String uuid;
+  final String title;
+  final String additionalText;
+  final Function onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    double containerWidth = MediaQuery.of(context).size.width - 10;
+
+    return Container(
+      width: containerWidth,
+      margin: const EdgeInsets.all(5),
+      padding: const EdgeInsets.all(10),
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        borderRadius:
+            BorderRadius.all(Radius.circular(constants.elementsBorderRadius)),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(left: 20),
+            child: Text(title,
+                style:
+                    const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(right: 20),
+            child: Row(
+              children: [
+                Text(additionalText, style: const TextStyle(fontSize: 14)),
+                const SizedBox(width: 10),
+                GestureDetector(
+                  onTap: () => onClose(),
+                  child: const Icon(Icons.close),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -118,6 +118,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_compass:
+    dependency: "direct main"
+    description:
+      name: flutter_compass
+      sha256: "1a0121bff32df95193812b4e0f69e95f45fdec042ebd7a326ba087c0f6ec8304"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -134,8 +142,21 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_map_location_marker:
+    dependency: "direct main"
+    description:
+      name: flutter_map_location_marker
+      sha256: "8fe2091e6fc53880e30462bf91d13ea0f156648e579adedf2eb797a32ed7a3af"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -147,6 +168,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
+  geolocator:
+    dependency: transitive
+    description:
+      name: geolocator
+      sha256: "5c23f3613f50586c0bbb2b8f970240ae66b3bd992088cf60dd5ee2e6f7dde3a8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.2"
+  geolocator_android:
+    dependency: transitive
+    description:
+      name: geolocator_android
+      sha256: "835ff5b4888a2f8eba128996494faf9c5d422785322a81dc0565b99e0f6c379d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.2"
+  geolocator_apple:
+    dependency: transitive
+    description:
+      name: geolocator_apple
+      sha256: "36527c555f4c425f7d8fa8c7c07d67b78e3ff7590d40448051959e1860c1cfb4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.7"
+  geolocator_platform_interface:
+    dependency: transitive
+    description:
+      name: geolocator_platform_interface
+      sha256: af4d69231452f9620718588f41acc4cb58312368716bfff2e92e770b46ce6386
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.7"
+  geolocator_web:
+    dependency: transitive
+    description:
+      name: geolocator_web
+      sha256: f68a122da48fcfff68bbc9846bb0b74ef651afe84a1b1f6ec20939de4d6860e1
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.6"
+  geolocator_windows:
+    dependency: transitive
+    description:
+      name: geolocator_windows
+      sha256: f5911c88e23f48b598dd506c7c19eff0e001645bdc03bb6fecb9f4549208354d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
   glob:
     dependency: transitive
     description:
@@ -307,6 +376,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.3"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "43798d895c929056255600343db8f049921cbec94d31ec87f1dc5c16c01935dd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
   polylabel:
     dependency: transitive
     description:
@@ -480,6 +557,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.1"
+  uuid:
+    dependency: "direct main"
+    description:
+      name: uuid
+      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.7"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,9 @@ dependencies:
   latlong2: ^0.9.0
   quickalert: ^1.0.1
   mocktail: ^1.0.0
-
+  flutter_map_location_marker: 7.0.2
+  flutter_compass: 0.7.0
+  uuid: ^3.0.7
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/pages/race/race_page_test.dart
+++ b/test/pages/race/race_page_test.dart
@@ -1,0 +1,48 @@
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:regatta_buddy/pages/race/race_page.dart';
+
+void main() {
+
+  testWidgets('Statistics are visible', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: RacePage()));
+
+    expect(find.text('Distance'), findsOneWidget);
+    expect(find.text('Time'), findsOneWidget);
+    expect(find.text('Avg. Speed'), findsOneWidget);
+  });
+
+  testWidgets('Can open actions modal', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: RacePage()));
+
+    expect(find.byIcon(Icons.warning_amber_rounded), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.warning_amber_rounded));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Needs help'), findsOneWidget);
+    expect(find.text('Protest'), findsOneWidget);
+    expect(find.text('Problem'), findsOneWidget);
+    expect(find.text('Cancel'), findsOneWidget);
+  });
+
+  testWidgets('Clicking action triggers notification which disappears after some time', (tester) async {
+    const int notificationVisibilityDuration = 10;
+    await tester.pumpWidget(const MaterialApp(home: RacePage()));
+
+    expect(find.byIcon(Icons.warning_amber_rounded), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.warning_amber_rounded));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Needs help'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Help requested'), findsOneWidget);
+
+    await tester.pumpAndSettle(const Duration(seconds: notificationVisibilityDuration + 1));
+
+    expect(find.text('Help requested'), findsNothing);
+  });
+}


### PR DESCRIPTION
Introducing a race page. View used by the race participants during the event.
📦 map with the current position
📦 race statistics (currently static values)
📦 actions button with modal
📦 notifications

![image](https://github.com/SomeBuddies/RegattaBuddy/assets/22868036/c01dd10d-0983-4583-9688-bf53c1b9b1bb)
![image](https://github.com/SomeBuddies/RegattaBuddy/assets/22868036/9188b516-5553-4642-8551-57aadc10e208)
![image](https://github.com/SomeBuddies/RegattaBuddy/assets/22868036/ffe2317f-d1ee-4985-bf71-24d788ea24f7)



